### PR TITLE
fugue-sql-antlr 0.2.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.2.4" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - triad >=0.6.8
     - packaging
   run_constrained:
-    - fugue-sql-antlr-cpp ==0.2.4
+    - fugue-sql-antlr-cpp =={{ version }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fugue-sql-antlr" %}
-{% set version = "0.2.2" %}
+{% set version = "0.2.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/fugue-project/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: f2c47e28673435b81da398df2dc3859490ad619a70974254b12e7c114e7f156c
+  sha256: 42701c3da50b519295580bbd6f8be7c6117b909337e1c9a29ccf3d00337ca99f
 
 build:
-  skip: true  # [py<38]
+  skip: true  # [py<310]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
@@ -22,12 +22,12 @@ requirements:
     - wheel
   run:
     - python
-    - antlr4-python3-runtime >=4.11.1,<4.12
+    - antlr4-python3-runtime >=4.13.2,<4.14
     - jinja2
     - triad >=0.6.8
     - packaging
   run_constrained:
-    - fugue-sql-antlr-cpp =={{ version }}
+    - fugue-sql-antlr-cpp ==0.2.4
 
 test:
   imports:


### PR DESCRIPTION
fugue-sql-antlr 0.2.4 

**Destination channel:** Defaults

### Links

- [PKG-16891]
- dev_url:        https://github.com/fugue-project/fugue-sql-antlr/tree/0.2.4
- conda_forge:    https://github.com/conda-forge/fugue-sql-antlr-feedstock
- pypi:           https://pypi.org/project/fugue-sql-antlr/0.2.4
- pypi inspector: https://inspector.pypi.io/project/fugue-sql-antlr/0.2.4

### Explanation of changes:

- new version number

### Tests:

- no rebuild required
- no downstream tests required


[PKG-16891]: https://anaconda.atlassian.net/browse/PKG-16891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ